### PR TITLE
Remove unsupported platforms from buildx_image_options in .woodpecker.yml

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,6 +1,6 @@
 variables:
   - &buildx_image "woodpeckerci/plugin-docker-buildx"
-  - &platforms "linux/amd64,linux/arm64,linux/arm/v7"
+  - &platforms "linux/amd64"
 
 pipeline:
   - name: Deploy to Docker Hub


### PR DESCRIPTION
This pull request addresses an issue in the .woodpecker.yml configuration file.

The unsupported platforms have been removed from the buildx_image_options, ensuring compatibility and preventing potential errors during the build process.