### PR TITLE
Fix composer install command and add step to copy application files in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,15 @@ ENV PATH="/composer/vendor/bin:$PATH" \
 # install composer
 COPY --from=composer:2.5.5 /usr/bin/composer /usr/bin/composer
 
-# install application dependencies
+# Copy composer files
 WORKDIR /var/www/app
 COPY ./src/composer.json ./src/composer.lock* ./
-RUN composer install --no-scripts --no-autoloader --ansi --no-interaction
+
+# Copy the application files
+COPY ./src .
+
+# install application dependencies
+RUN composer install --no-scripts --ansi --no-interaction
 
 # add custom php-fpm pool settings, these get written at entrypoint startup
 ENV FPM_PM_MAX_CHILDREN=20 \
@@ -36,7 +41,6 @@ COPY ./docker/default.conf /etc/nginx/conf.d/default.conf
 
 # copy application code
 WORKDIR /var/www/app
-COPY ./src .
 RUN composer dump-autoload -o \
     && chown -R :www-data /var/www/app \
     && chmod -R 775 /var/www/app/storage /var/www/app/bootstrap/cache


### PR DESCRIPTION
This pull request addresses two issues in the Dockerfile that impact the composer installation process.

Firstly, the composer install command has been fixed by including the copying of composer files before running the command. This ensures that all the necessary dependencies are correctly installed.