### PR TITLE
Update CleanUpExpiredATISAudioFiles job schedule frequency

### DIFF
--- a/src/app/Console/Kernel.php
+++ b/src/app/Console/Kernel.php
@@ -14,9 +14,8 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule)
     {
         $schedule->job(new CleanUpExpiredATISAudioFiles, 'default', 'database')
-            ->hourly()
+            ->everyThirtyMinutes()
             ->withoutOverlapping()
-            ->timezone("America/New_York")
             ->appendOutputTo("scheduler-output.log");
     }
 

--- a/src/app/Jobs/CleanUpExpiredATISAudioFiles.php
+++ b/src/app/Jobs/CleanUpExpiredATISAudioFiles.php
@@ -31,7 +31,7 @@ class CleanUpExpiredATISAudioFiles implements ShouldQueue
      */
     public function handle(): void
     {
-        Log::info('Cleaning up expired ATIS audio files...');
+        Log::info('Searching for expired ATIS audio files...');
 
         // Get all expired ATIS audio files
         $expiredATISAudioFiles = ATISAudioFile::where('expires_at', '<', now())->get();


### PR DESCRIPTION
This pull request updates the schedule frequency of the CleanUpExpiredATISAudioFiles job in the Kernel.php file. Instead of running hourly, it will now run every thirty minutes. Additionally, the log message in the CleanUpExpiredATISAudioFiles.php file has been changed from "Cleaning up expired ATIS audio files..." to "Searching for expired ATIS audio files..." for better clarity.